### PR TITLE
Configure meeting notes issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: acmcsufoss
+    url: https://oss.acmcsuf.com/
+    about: Contribute to this organization's open source projects.
+  - name: acmcsuf.com
+    url: https://acmcsuf.com/
+    about: See what's good with ACM at CSUF.

--- a/.github/ISSUE_TEMPLATE/meeting.yaml
+++ b/.github/ISSUE_TEMPLATE/meeting.yaml
@@ -1,26 +1,53 @@
 name: Meeting
-description: A meeting issue template for Open Source Software team meetings.
-labels: 'meeting'
+description: Create meeting notes 🚀
+title: "[Meeting] <title>"
+labels: ["meeting"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        ![banner](https://raw.githubusercontent.com/EthanThatOneKid/acmcsuf.com/main/static/assets/about-illustration.svg)
-        <small>note: banner not included in your issue.</small>
-  - type: textarea
-    attributes:
-      label: What happened?
-      description: |
-        Can you please explain what happened, what you saw, what you expected to see, and any other relevant information? Please drag and drop any screenshots here.
-      placeholder: Type away! Feel free to drag-and-drop any screenshots here.
-    validations:
-      required: false
-
-# TODO: Finish meeting.yaml template file.
-
-# Reference:
-# - - https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#converting-a-markdown-issue-template-to-a-yaml-issue-form-template
-# - https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#keys
-# - https://github.com/users/EthanThatOneKid/projects/6/views/8
-# - https://github.com/EthanThatOneKid/acmcsuf.com/blob/main/.github/ISSUE_TEMPLATE/bug_report.yaml?plain=1
-# - https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
+- type: markdown
+  attributes:
+    label: 🙋 Participants
+    description: Mention the participants who attended the meeting.
+  validations:
+    required: true
+- type: markdown
+  attributes:
+    label: 📍 Meeting location
+    description: Where the meeting was held.
+  validations:
+    required: true
+- type: markwdown
+  attributes:
+    label: 🗓️ Meeting date and time
+    description: Date and time when the meeting started.
+  validations:
+    required: true
+- type: markdown
+  attributes:
+    label: ⏳ Meeting duration estimate
+    description: Estimate how long the meeting will take.
+  validations:
+    required: true
+- type: markdown
+  attributes:
+    label: 📋 Meeting agenda
+    description: Break down the meeting topics, talking points, and agenda items.
+  validations:
+    required: true
+- type: markdown
+  attributes:
+    label: 🚀 Meeting updates
+    description: Summarize the exciting updates and discussions from the meeting.
+  validations:
+    required: false
+- type: markdown
+  attributes:
+    label: 📝 Meeting action items
+    description: List the action items assigned during the meeting.
+  validations:
+    required: false
+- type: markdown
+  attributes:
+    label: 🌟 Meeting wrap-up
+    description: Closing remarks, schedule the next meeting, and record the adjournment time.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/meeting.yaml
+++ b/.github/ISSUE_TEMPLATE/meeting.yaml
@@ -1,0 +1,26 @@
+name: Meeting
+description: A meeting issue template for Open Source Software team meetings.
+labels: 'meeting'
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ![banner](https://raw.githubusercontent.com/EthanThatOneKid/acmcsuf.com/main/static/assets/about-illustration.svg)
+        <small>note: banner not included in your issue.</small>
+  - type: textarea
+    attributes:
+      label: What happened?
+      description: |
+        Can you please explain what happened, what you saw, what you expected to see, and any other relevant information? Please drag and drop any screenshots here.
+      placeholder: Type away! Feel free to drag-and-drop any screenshots here.
+    validations:
+      required: false
+
+# TODO: Finish meeting.yaml template file.
+
+# Reference:
+# - - https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#converting-a-markdown-issue-template-to-a-yaml-issue-form-template
+# - https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#keys
+# - https://github.com/users/EthanThatOneKid/projects/6/views/8
+# - https://github.com/EthanThatOneKid/acmcsuf.com/blob/main/.github/ISSUE_TEMPLATE/bug_report.yaml?plain=1
+# - https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "denoland.vscode-deno"
+}


### PR DESCRIPTION
### Objective

Our goal is to create a new [issue template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#converting-a-markdown-issue-template-to-a-yaml-issue-form-template) designed specifically for recurring meeting notes. Given that our code, issues, pull requests, and contributors are all managed on GitHub, it makes sense for our meeting notes to reside here too.

### Legacy meeting notes

Historically, we have been documenting our recurring meeting notes using cumbersome Google Document tables[^1], which we duplicated from a blank template every time we needed to record a meeting.

![Screenshot of legacy meeting notes table in Google Docs (dark mode)](https://github.com/acmcsufoss/i/assets/31261035/78b41996-d343-4fda-8ae1-96d63229fc48)

### Reference

- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema

[^1]: https://acmcsuf.com/oss-sync#heading=h.e8kg90t55htv